### PR TITLE
Rebalancing the Pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
 >> - mimosacb
 >> - McCsocks
 
-> In all subsequent rounds, the player order is shuffled after the last turn of the previous round such that the player order proceeds from least to most points. This action shall be referred to as "The Pip Shuffle" and will be coordinated by the moderators.
+> In all subsequent rounds, the player order is shuffled after the last turn of the previous round such that the player order proceeds from most to least points. This action shall be referred to as "The Pip Shuffle" and will be coordinated by the moderators.
 
 [[1](https://github.com/stolksdorf/nomic/pull/1)]
 [[2](https://github.com/stolksdorf/nomic/pull/2)]


### PR DESCRIPTION
I'm tremendously sorry for taking so long!  Somebody should make a rule that doesn't allow douchebags like me to stall the game.

Onto the rule change itself:
So far we have only invented rules that provide _additional_ points.  If such a trend continues, using the original Pip Shuffle, the players at the beginning of the round will always earn fewer points than those at the end.  I propose this change to re-balance the points distribution, until we either start losing points or points become irrelevant.

And now my joke:

> A dyslexic man walked into a bra.
> 
> His wife's washing was hanging out to dry and he wasn't looking where he was going. The man's dyslexia was admittedly pretty irrelevant to the event.
