### PR TITLE
man what do I even put in this box

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@
 
 [[7](https://github.com/stolksdorf/nomic/pull/7)]
 
+----
+
+##### 110: Let's Keep This Gravy Train Rolling
+> If the current player in the turn order does not propose a rule within three days of their turn starting, that player is moved to the bottom of the turn order and the turn passes to the next player. The second time a player's turn is passed during a single round, they are not moved to the bottom of the turn order, thereby losing their turn for that round entirely.
+
 <sup>1</sup>[how2play.md - the arbiter](https://github.com/stolksdorf/nomic/blob/master/how2play.md#the-arbiter)
 
 ----


### PR DESCRIPTION
Yeah. And yes, it is entertaining that it has taken me a week to propose this rule. Sorry, I done been sick. Anyways, point of the rule is obvious. Keep the game moving regardless of how long people like myself and Jared take for our turns, but without really punishing people for being forgetful / inattentive. Unless they do it twice. Although that could also play into the Rule of Timely Completion. Ho ho ho!

Also we should make sure people are alerted when their turns start, 'cause I didn't realize it was my go until a couple days ago when I started figuring out how to word this, and even then I got Jared to help me with it :P

For my Mackenzie-Buck, I'm going to go a different route than the previous players. Instead of a joke, I'm going with the inspirational quote.

"The night is darkest just before the dawn."

While not strictly true (depending on how we define dawn), I've always liked this quote. It's been said by a few people in the past, but I remember it most from Lulu in Final Fantasy X, because I'm cool.
